### PR TITLE
Rework database to avoid race conditions

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -209,12 +209,11 @@ func HandleUpdateCheckingInterval(w http.ResponseWriter, r *http.Request) {
 		ReturnResponse(w, errRes)
 		return
 	}
-	target := DownloadTarget{Type: interval.Type}
-	res, err := target.UpdateCheckingInterval(interval.CheckingInterval)
+	err = UpdateCheckingInterval(interval.Type, interval.CheckingInterval)
 	if err != nil {
 		errRes = Response{Type: "Error", Key: "ERROR_UPDATING_CHECKING_INTERVAL", Message: "There was an updating the checking interval: " + err.Error()}
 		ReturnResponse(w, errRes)
 		return
 	}
-	ReturnResponse(w, res)
+	ReturnResponse(w, Response{Type: "Success", Key: "UPDATE_CHECKING_INTERVAL_SUCCESS", Message: "Successfully updated the checking interval"})
 }

--- a/main.go
+++ b/main.go
@@ -46,9 +46,9 @@ func init() {
 }
 
 func uploadCheckerChannels() {
-	interval, err := GetCheckingInterval("channels")
+	interval, err := GetCheckingInterval(TypeChannel)
 	if err != nil {
-		log.Errorf("uploadCheckerChannels: %s", err)
+		log.Errorf("uploadCheckerChannels: %v", err)
 	}
 	if interval == 0 {
 		time.Sleep(5 * time.Minute)
@@ -65,9 +65,9 @@ func uploadCheckerChannels() {
 }
 
 func uploadCheckerPlaylists() {
-	interval, err := GetCheckingInterval("playlists")
+	interval, err := GetCheckingInterval(TypePlaylist)
 	if err != nil {
-		log.Errorf("uploadCheckerPlaylists: %s", err)
+		log.Errorf("uploadCheckerPlaylists: %v", err)
 	}
 	if interval == 0 {
 		time.Sleep(5 * time.Minute)

--- a/structs.go
+++ b/structs.go
@@ -1,5 +1,7 @@
 package main
 
+import "sync"
+
 type TargetMetadata struct {
 	PlaylistUploader   string      `json:"playlist_uploader"`
 	UploadDate         string      `json:"upload_date"`
@@ -197,4 +199,11 @@ type YTDLCommand struct {
 	FileType     string
 	Output       string
 	Target       string
+}
+
+type Database struct {
+	*sync.RWMutex
+	file     string
+	contents []DownloadTarget
+	lookup   map[string]*DownloadTarget
 }

--- a/videos_database_handlers.go
+++ b/videos_database_handlers.go
@@ -5,19 +5,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 )
 
 func (v DownloadVideoPayload) AddToDatabase() error {
-	byteValue, err := openJSONDatabase(CONFIG_ROOT + "videos.json")
+	b, err := ioutil.ReadFile(filepath.Join(CONFIG_ROOT, "videos.json"))
 	if err != nil {
 		return fmt.Errorf("v.AddToDatabase: %s", err)
 	}
 
 	var videos []DownloadVideoPayload
 
-	json.Unmarshal(byteValue, &videos)
+	json.Unmarshal(b, &videos)
 
 	log.Info("adding video to DB")
 	videos = append(videos, v)


### PR DESCRIPTION
The old system relied on global variables, this rework uses the sync.RWMutex struct to synchronize access and modifications. 
A hashmap is used for DownloadTarget lists as well to reduce the amount of times a full iteration of the list is needed.